### PR TITLE
Added error message in case of incorrect credentials

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -72,7 +72,7 @@ export const LibreLinkUpClient = ({
       password,
     });
 
-    if (loginResponse.data.status !== 200) throw new Error('Bad credentials. Please ensure that you have entered the credentials of your LibreLinkUp account (and not of your LibreLink account).');
+    if (loginResponse.data.status === 2) throw new Error('Bad credentials. Please ensure that you have entered the credentials of your LibreLinkUp account (and not of your LibreLink account).');
 
     if ((loginResponse.data as LoginRedirectResponse).data.redirect) {
       const redirectResponse = loginResponse.data as LoginRedirectResponse;

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,6 +72,8 @@ export const LibreLinkUpClient = ({
       password,
     });
 
+    if (loginResponse.data.status !== 200) throw new Error('Bad credentials. Please ensure that you have entered the credentials of your LibreLinkUp account (and not of your LibreLink account).');
+
     if ((loginResponse.data as LoginRedirectResponse).data.redirect) {
       const redirectResponse = loginResponse.data as LoginRedirectResponse;
       const countryNodes = await instance.get<CountryResponse>(


### PR DESCRIPTION
The current error we get when it's not the right credentials is this one: `TypeError: Cannot read properties of undefined (reading 'redirect')`

The new error message will help people to understand what's wrong (see https://github.com/DiaKEM/libre-link-up-api-client/issues/16 for more details.)