### PR TITLE
Bumped LLU app version in header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -48,7 +48,7 @@ export const LibreLinkUpClient = ({
       connection: 'Keep-Alive',
       'content-type': 'application/json',
       product: 'llu.android',
-      version: '4.2.1',
+      version: '4.7.0',
     },
   });
   instance.interceptors.request.use(


### PR DESCRIPTION
Bump the application version for the request headers. This allows the client to work again, after the recent API changes