### PR TITLE
inject version and switch to 4.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ also do it if your session expires.
 ```javascript
 import {LibreLinkUpClient} from '@diakem/libre-link-up-api-client';
 
-const {read} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!'});
+const {read} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', version: '4.9.0'});
 
 const response = await read();
 ```
@@ -49,7 +49,7 @@ You have also the possibility to retrieve the raw response returned by the shari
 ```javascript
 import {LibreLinkUpClient} from '@diakem/libre-link-up-api-client';
 
-const {readRaw} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!'});
+const {readRaw} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', version: '4.9.0'});
 
 const response = await readRaw();
 ```
@@ -75,7 +75,7 @@ Get average data.
 ```javascript
 import {LibreLinkUpClient} from '@diakem/libre-link-up-api-client';
 
-const {readAveraged} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!'});
+const {readAveraged} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', version: '4.9.0'});
 
 const callback = (average, memory) => {
   console.log({

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ also do it if your session expires.
 ```javascript
 import {LibreLinkUpClient} from '@diakem/libre-link-up-api-client';
 
-const {read} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', version: '4.9.0'});
+const {read} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', clientVersion: '4.9.0'});
 
 const response = await read();
 ```
@@ -49,7 +49,7 @@ You have also the possibility to retrieve the raw response returned by the shari
 ```javascript
 import {LibreLinkUpClient} from '@diakem/libre-link-up-api-client';
 
-const {readRaw} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', version: '4.9.0'});
+const {readRaw} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', clientVersion: '4.9.0'});
 
 const response = await readRaw();
 ```
@@ -75,7 +75,7 @@ Get average data.
 ```javascript
 import {LibreLinkUpClient} from '@diakem/libre-link-up-api-client';
 
-const {readAveraged} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', version: '4.9.0'});
+const {readAveraged} = LibreLinkUpClient({username: 'myLibreLinkUpEmailAddress', password: 'pAssw0rd!', clientVersion: '4.9.0'});
 
 const callback = (average, memory) => {
   console.log({

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -3,11 +3,11 @@ import { LibreLinkUpClient } from './client';
 (async function () {
   const username = 'USERNAME';
   const password = 'PASSWORD';
-  const version = '4.9.0';
+  const clientVersion = '4.9.0';
   const libreClient = LibreLinkUpClient({
     username,
     password,
-    version,
+    clientVersion,
     connectionIdentifier: 'IDENTIFIER',
   });
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -3,9 +3,11 @@ import { LibreLinkUpClient } from './client';
 (async function () {
   const username = 'USERNAME';
   const password = 'PASSWORD';
+  const version = '4.9.0';
   const libreClient = LibreLinkUpClient({
     username,
     password,
+    version,
     connectionIdentifier: 'IDENTIFIER',
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ const LIBRE_LINK_SERVER = 'https://api-us.libreview.io';
 type ClientArgs = {
   username: string;
   password: string;
-  version: string;
+  clientVersion: string;
   connectionIdentifier?: string | ((connections: Datum[]) => string);
 };
 
@@ -36,7 +36,7 @@ const urlMap = {
 export const LibreLinkUpClient = ({
   username,
   password,
-  version,
+  clientVersion,
   connectionIdentifier,
 }: ClientArgs) => {
   let jwtToken: string | null = null;
@@ -50,7 +50,7 @@ export const LibreLinkUpClient = ({
       connection: 'Keep-Alive',
       'content-type': 'application/json',
       product: 'llu.android',
-      version: version,
+      version: clientVersion,
     },
   });
   instance.interceptors.request.use(
@@ -74,7 +74,10 @@ export const LibreLinkUpClient = ({
       password,
     });
 
-    if (loginResponse.data.status === 2) throw new Error('Bad credentials. Please ensure that you have entered the credentials of your LibreLinkUp account (and not of your LibreLink account).');
+    if (loginResponse.data.status === 2)
+      throw new Error(
+        'Bad credentials. Please ensure that you have entered the credentials of your LibreLinkUp account (and not of your LibreLink account).'
+      );
 
     if ((loginResponse.data as LoginRedirectResponse).data.redirect) {
       const redirectResponse = loginResponse.data as LoginRedirectResponse;

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,7 @@ const LIBRE_LINK_SERVER = 'https://api-us.libreview.io';
 type ClientArgs = {
   username: string;
   password: string;
+  version: string;
   connectionIdentifier?: string | ((connections: Datum[]) => string);
 };
 
@@ -35,6 +36,7 @@ const urlMap = {
 export const LibreLinkUpClient = ({
   username,
   password,
+  version,
   connectionIdentifier,
 }: ClientArgs) => {
   let jwtToken: string | null = null;
@@ -48,7 +50,7 @@ export const LibreLinkUpClient = ({
       connection: 'Keep-Alive',
       'content-type': 'application/json',
       product: 'llu.android',
-      version: '4.7.0',
+      version: version,
     },
   });
   instance.interceptors.request.use(


### PR DESCRIPTION
Hi, I notice that in its current state this library doesn't work right now.

The `version` provided in the http headers to the API is fixed at `4.7.0` which is no longer accepted by the European servers.

This PR allows users of the library to set the API version to future poof around this problem and updates the README to suggest users provide version `4.9.0`, which according to my testing with BURP is the value currently supplied by the LibreLinkUp app.

I'm not versed in, or familiar with writing or testing TypeScript code or working with node, so if you need extra changes to accept this PR and release a new version of the library please let me know and I'll do my best to get the PR into a mergeable state.